### PR TITLE
Format token values as px instead of strings (Fixes #9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.2.0 (2018-06-05)
+
+### Bug Fixes
+
+* **units:** units are now formatted correctly as pixel values instead of strings (#9)
+
 # 1.1.0 (2018-05-15)
 
 ### Bug Fixes

--- a/gulp/_default.js
+++ b/gulp/_default.js
@@ -24,6 +24,6 @@ gulp.task('clean', () => del('./dist'));
 gulp.task('default', (done) => {
     runSequence(
         ['clean'],
-        ['_index', 'breakpoints', 'colors', 'gradients', 'font-stack', 'units'],
+        ['_index', 'breakpoints', 'content', 'colors', 'gradients', 'font-stack', 'units'],
         done);
 });

--- a/gulp/content.js
+++ b/gulp/content.js
@@ -1,0 +1,22 @@
+const gulp = require('gulp');
+const gulpTheo = require('gulp-theo');
+
+// Formats with px values
+const unitsFormats = [
+    'custom-properties.css',
+    'common.js',
+    'json',
+    'less',
+    'scss'
+];
+
+gulp.task('content', () => {
+    unitsFormats.map((format) => {
+        gulp.src('tokens/content.yml')
+            .pipe(gulpTheo({
+                transform: { includeMeta: true },
+                format: { type: format }
+            }))
+            .pipe(gulp.dest('dist/content'));
+    });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mozilla-protocol/tokens",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Design tokens for Protocol, Mozilla’s design system",
   "main": "dist/index.js",
   "style": "dist/index.scss",

--- a/tokens/_index.yml
+++ b/tokens/_index.yml
@@ -1,5 +1,6 @@
 imports:
   - ./breakpoints.yml
+  - ./content.yml
   - ./colors.yml
   - ./font-stack.yml
   - ./gradients.yml

--- a/tokens/breakpoints.yml
+++ b/tokens/breakpoints.yml
@@ -5,30 +5,6 @@ imports:
   - ./_aliases.yml
 props:
 
-  - name: 'content-xs'
-    value: '{!content-xs}'
-  - name: 'content-sm'
-    value: '{!content-sm}'
-  - name: 'content-md'
-    value: '{!content-md}'
-  - name: 'content-lg'
-    value: '{!content-lg}'
-  - name: 'content-xl'
-    value: '{!content-xl}'
-  - name: 'content-max'
-    value: '{!content-max}'
-
-  - name: 'screen-xs'
-    value: '{!content-xs}'
-  - name: 'screen-sm'
-    value: '{!content-sm}'
-  - name: 'screen-md'
-    value: '{!content-md}'
-  - name: 'screen-lg'
-    value: '{!content-lg}'
-  - name: 'screen-xl'
-    value: '{!content-xl}'
-
   - name: 'mq-xs'
     value: '{!mq-xs}'
   - name: 'mq-sm'

--- a/tokens/content.yml
+++ b/tokens/content.yml
@@ -1,0 +1,30 @@
+global:
+  type: web
+  category: width
+imports:
+  - ./_aliases.yml
+props:
+
+  - name: 'content-xs'
+    value: '{!content-xs}'
+  - name: 'content-sm'
+    value: '{!content-sm}'
+  - name: 'content-md'
+    value: '{!content-md}'
+  - name: 'content-lg'
+    value: '{!content-lg}'
+  - name: 'content-xl'
+    value: '{!content-xl}'
+  - name: 'content-max'
+    value: '{!content-max}'
+
+  - name: 'screen-xs'
+    value: '{!content-xs}'
+  - name: 'screen-sm'
+    value: '{!content-sm}'
+  - name: 'screen-md'
+    value: '{!content-md}'
+  - name: 'screen-lg'
+    value: '{!content-lg}'
+  - name: 'screen-xl'
+    value: '{!content-xl}'

--- a/tokens/units.yml
+++ b/tokens/units.yml
@@ -1,7 +1,7 @@
 # Note: aliases can't be referenced in meta values
 
 global:
-  type: string
+  type: web
   category: padding
 imports:
   - ./_aliases.yml


### PR DESCRIPTION
Fixes https://github.com/mozilla/protocol-tokens/issues/9