### PR TITLE
Remove extraneous trailing comma from json data formatting (Fixes #20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.3.1 (2018-06-27)
+
+### Bug Fixes
+
+* **json:** Remove extraneous trailing comma from json data formatting (#20)
+
 # 1.3.0 (2018-06-21)
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Design tokens for Protocol, Mozilla’s design system.
 </tr>
 <tr>
 <td>Version</td>
-<td><a href="https://github.com/mozilla/protocol-tokens/blob/master/CHANGELOG.md">1.3.0</a></td>
+<td><a href="https://github.com/mozilla/protocol-tokens/blob/master/CHANGELOG.md">1.3.1</a></td>
 </tr>
 </table>
 

--- a/gulp/_default.js
+++ b/gulp/_default.js
@@ -14,7 +14,7 @@ theo.registerFormat('json', `[
     "name": "{{prop.name}}",
     {{/if}}
     "value": "{{prop.value}}",
-    "token": "\${{prop.name}}",
+    "token": "\${{prop.name}}"
   }{{#unless @last}},{{/unless}}{{/each}}
 ]
 `);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mozilla-protocol/tokens",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mozilla-protocol/tokens",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Design tokens for Protocol, Mozilla’s design system",
   "main": "dist/index.js",
   "style": "dist/index.scss",


### PR DESCRIPTION
Fixes https://github.com/mozilla/protocol-tokens/issues/20