### PR TITLE
[fix #49] Update font stacks, add Inter and Metropolis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Head
+
+* **fontstack** (breaking) Adds Inter and Metropolis to the font stacks. Adds new variables for base and brand themes, removing `font-stack-sans` and `font-stack-serif`.
+* **colors:** Update color values to latest Firefox brand guide
+
 # 3.0.0 (2019-03-25)
 
 ### Features

--- a/tokens/_aliases.yml
+++ b/tokens/_aliases.yml
@@ -151,7 +151,7 @@ aliases:
   spacing-lg: '24px'
   spacing-xl: '32px'
   spacing-2xl: '48px'
-  
+
   layout-2xs: '16px'
   layout-xs: '24px'
   layout-sm: '32px'
@@ -187,6 +187,7 @@ aliases:
   mq-high-res: 'only screen and (-webkit-min-device-pixel-ratio: 1.5), only screen and (min-resolution: 1.5dppx), only screen and (min-resolution: 144dpi)'
 
   # Font Stack
-  font-stack-sans: "'Open Sans', X-LocaleSpecific, sans-serif"
-  font-stack-serif: "'Zilla Slab', 'Open Sans', X-LocaleSpecific, serif"
+  font-stack-base: "Inter, X-LocaleSpecific, sans-serif"
+  font-stack-firefox: "Metropolis, Inter, X-LocaleSpecific, sans-serif"
   font-stack-mono: "Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace"
+  font-stack-mozilla: "'Zilla Slab', Inter, X-LocaleSpecific, sans-serif"

--- a/tokens/font-stack.yml
+++ b/tokens/font-stack.yml
@@ -4,9 +4,11 @@ global:
 imports:
   - ./_aliases.yml
 props:
-  - name: font-stack-sans
-    value: '{!font-stack-sans}'
-  - name: font-stack-serif
-    value: '{!font-stack-serif}'
+  - name: font-stack-base
+    value: '{!font-stack-base}'
+  - name: font-stack-firefox
+    value: '{!font-stack-firefox}'
+  - name: font-stack-mozilla
+    value: '{!font-stack-mozilla}'
   - name: font-stack-mono
     value: '{!font-stack-mono}'


### PR DESCRIPTION
## Description

Updates the font stack tokens to add Inter and Metropolis, and renames the tokens to match our current approach to brand theming. Those name changes **will break** anything that references the old token names.

- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

#49 
