### PR TITLE
[fix #52] Add Mozilla brand colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
-# 4.0.0 (2019-09-13)
+# HEAD
 
 * **colors:** Add Mozilla brand colors
+
+# 4.0.0 (2019-09-13)
+
 * **fontstack** (breaking) Adds Inter and Metropolis to the font stacks. Adds new variables for base and brand themes, removing `font-stack-sans` and `font-stack-serif`.
 * **colors:** Update color values to latest Firefox brand guide
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 4.0.0 (2019-09-13)
 
+* **colors:** Add Mozilla brand colors
 * **fontstack** (breaking) Adds Inter and Metropolis to the font stacks. Adds new variables for base and brand themes, removing `font-stack-sans` and `font-stack-serif`.
 * **colors:** Update color values to latest Firefox brand guide
 

--- a/tokens/_aliases.yml
+++ b/tokens/_aliases.yml
@@ -138,11 +138,21 @@ aliases:
   color-white: '#ffffff'
 
   # Link Colors
-
   color-link: '{!color-blue-50}'
   color-link-hover: '{!color-blue-60}'
   color-link-visited: '{!color-purple-50}'
   color-link-visited-hover: '{!color-purple-60}'
+
+  # Mozilla brand colors
+  color-moz-neon-blue: '#00ffff'
+  color-moz-lemon-yellow: '#fff44f'
+  color-moz-warm-red: '#ff4f5e'
+  color-moz-neon-green: '#54ffbd'
+  color-moz-dark-purple: '#6e008b'
+  color-moz-dark-green: '#005e5e'
+  color-moz-dark-blue: '#00458b'
+  color-moz-dark-gray: '#959595'
+  color-moz-light-gray: '#e7e5e2'
 
   # Units
   spacing-xs: '4px'

--- a/tokens/colors.yml
+++ b/tokens/colors.yml
@@ -509,7 +509,6 @@ props:
     value: '{!color-white}'
     meta:
       friendlyName: White
-  
 
   # Link Colors
 
@@ -529,3 +528,42 @@ props:
     value: '{!color-link-visited-hover}'
     meta:
       friendlyName: Link:Visited:Hover
+
+# Mozilla brand colors
+
+  - name: color-moz-neon-blue
+    value: '{!color-moz-neon-blue}'
+    meta:
+      friendlyName: Mozilla Neon Blue
+  - name: color-moz-lemon-yellow
+    value: '{!color-moz-lemon-yellow}'
+    meta:
+      friendlyName: Mozilla Lemon Yellow
+  - name: color-moz-warm-red
+    value: '{!color-moz-warm-red}'
+    meta:
+      friendlyName: Mozilla Warm Red
+  - name: color-moz-neon-green
+    value: '{!color-moz-neon-green}'
+    meta:
+      friendlyName: Mozilla Neon Green
+  - name: color-moz-dark-purple
+    value: '{!color-moz-dark-purple}'
+    meta:
+      friendlyName: Mozilla Dark Purple
+  - name: color-moz-dark-green
+    value: '{!color-moz-dark-green}'
+    meta:
+      friendlyName: Mozilla Dark Green
+  - name: color-moz-dark-blue
+    value: '{!color-moz-dark-blue}'
+    meta:
+      friendlyName: Mozilla Dark Blue
+  - name: color-moz-dark-gray
+    value: '{!color-moz-dark-gray}'
+    meta:
+      friendlyName: Mozilla Dark Gray
+  - name: color-moz-light-gray
+    value: '{!color-moz-light-gray}'
+    meta:
+      friendlyName: Mozilla Light Gray


### PR DESCRIPTION
## Description

Adds back the Mozilla brand colors. The tokens are namespaced with a `-moz-` to avoid collisions with other tokens, as well as help us to be mindful not to mix brand palettes.

- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

#52 