### PR TITLE
Add tokens for border-radius

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # HEAD
 
+* **borders** Add tokens for border radii
 * **colors** (breaking) Rename "grey" colors to the American spelling of "gray"
 * **colors:** Add Mozilla brand colors
 

--- a/tokens/_aliases.yml
+++ b/tokens/_aliases.yml
@@ -1,7 +1,12 @@
 aliases:
 
-  # Colors
+  # Borders
+  border-radius-xs: '2px'
+  border-radius-sm: '4px'
+  border-radius-md: '8px'
+  border-radius-lg: '16px'
 
+  # Colors
   color-green-05: '#e3fff3'
   color-green-10: '#d1ffee'
   color-green-20: '#b3ffe3'

--- a/tokens/_index.yml
+++ b/tokens/_index.yml
@@ -5,3 +5,4 @@ imports:
   - ./font-stack.yml
   - ./gradients.yml
   - ./units.yml
+  - ./border-radius.yml

--- a/tokens/border-radius.yml
+++ b/tokens/border-radius.yml
@@ -1,0 +1,16 @@
+global:
+  type: web
+  category: border-radius
+imports:
+  - ./_aliases.yml
+props:
+
+  - name: 'border-radius-xs'
+    value: '{!border-radius-xs}'
+  - name: 'border-radius-sm'
+    value: '{!border-radius-sm}'
+  - name: 'border-radius-md'
+    value: '{!border-radius-md}'
+  - name: 'border-radius-lg'
+    value: '{!border-radius-lg}'
+

--- a/tokens/gradients.yml
+++ b/tokens/gradients.yml
@@ -27,4 +27,3 @@ props:
       type: 'linear'
       angle: '90deg'
       value: '#FFFFFF, #FFF44F'
-  


### PR DESCRIPTION
## Description
Adds tokens for standard border radii (for rounded corners) following our standard "shirt size" convention.

```
  border-radius-xs: '2px'
  border-radius-sm: '4px'
  border-radius-md: '8px'
  border-radius-lg: '16px'
```

- [x] I have recorded this change in `CHANGELOG.md`.

### Issue
Fixes https://github.com/mozilla/protocol/issues/457
