### PR TITLE
Bump version to 5.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 5.0.1 (2019-12-06)
+
+### Bug Fixes
+
+* **package:** update dist folder, erroneously published with outdated contents
+
 # 5.0.0 (2019-12-05)
 
 * **shadows:** Add tokens for box shadows

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Design tokens for Protocol, Mozilla’s design system.
 </tr>
 <tr>
 <td>Version</td>
-<td><a href="https://github.com/mozilla/protocol-tokens/blob/master/CHANGELOG.md">5.0.0</a></td>
+<td><a href="https://github.com/mozilla/protocol-tokens/blob/master/CHANGELOG.md">5.0.1</a></td>
 </tr>
 </table>
 
@@ -83,6 +83,13 @@ a {
   color: var(--color-black);
 }
 ```
+
+## Publishing
+
+To publish to the npmjs registry you'll need access to the mozilla-protocol org on npmjs.com.
+First run `gulp` to compile the package locally. You can check your local `dist`
+folder to verify it has the up-to-date tokens. Then run `npm publish`.
+
 
 ## Contributing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mozilla-protocol/tokens",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mozilla-protocol/tokens",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Design tokens for Protocol, Mozilla’s design system",
   "main": "dist/index.js",
   "style": "dist/index.scss",


### PR DESCRIPTION
## Description

When I published 5.0.0 I had an outdated local dist folder, so none of the new tokens actually got published. This version bump will let me fix that, and I've also added a bit to the readme to remind us to run gulp first so I don't screw this up again 🤦‍♂ 

- [x] I have recorded this change in `CHANGELOG.md`.
