### PR TITLE
Bump version to 5.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# HEAD
+# 5.0.2 (2020-01-08)
 
 * **media queries:** Update $screen-lg and media queries
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Design tokens for Protocol, Mozilla’s design system.
 </tr>
 <tr>
 <td>Version</td>
-<td><a href="https://github.com/mozilla/protocol-tokens/blob/master/CHANGELOG.md">5.0.1</a></td>
+<td><a href="https://github.com/mozilla/protocol-tokens/blob/master/CHANGELOG.md">5.0.2</a></td>
 </tr>
 </table>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mozilla-protocol/tokens",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mozilla-protocol/tokens",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Design tokens for Protocol, Mozilla’s design system",
   "main": "dist/index.js",
   "style": "dist/index.scss",


### PR DESCRIPTION
## Description

Updates to 5.0.2 so we can publish the [recently changed screen sizes and media queries](https://github.com/mozilla/protocol-tokens/commit/68ce550a23b6d087f3b4232bbcc5f4362ff2bf1c).

- [x] I have recorded this change in `CHANGELOG.md`.
