### PR TITLE
Bump version to 5.0.3 to fix light-gray-05

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 5.0.3 (2020-02-11)
+
+### Bug Fixes
+
+* **colors:** Remove repeated definition of color-light-gray-05
+
+
 # 5.0.2 (2020-01-08)
 
 * **media queries:** Update $screen-lg and media queries

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mozilla-protocol/tokens",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mozilla-protocol/tokens",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "description": "Design tokens for Protocol, Mozilla’s design system",
   "main": "dist/index.js",
   "style": "dist/index.scss",

--- a/tokens/colors.yml
+++ b/tokens/colors.yml
@@ -337,10 +337,6 @@ props:
     value: '{!color-light-gray-05}'
     meta:
       friendlyName: Light Gray 05
-  - name: color-light-gray-05
-    value: '{!color-light-gray-05}'
-    meta:
-      friendlyName: Light Gray 05
   - name: color-light-gray-10
     value: '{!color-light-gray-10}'
     meta:
@@ -509,7 +505,7 @@ props:
     value: '{!color-white}'
     meta:
       friendlyName: White
-  
+
 
   # Link Colors
 


### PR DESCRIPTION
## Description

Some bad copy-pasta resulted in defining color-light-gray-05 twice, which when compiled was duplicating the value and causing other trouble. This removes the dupe and bumps the version so we can publish the fix.

- [x] I have recorded this change in `CHANGELOG.md`.

### Testing

Check the compiled files and verify that color-light-gray-05 doesn't have a repeated value.