### PR TITLE
[fix #78] change type to font-family to prevent quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
+# HEAD
+
+### Bug Fixes
+
+* **fontstack:** Change type to 'font-family' to prevent quotes (#78)
+
 # 5.0.3 (2020-02-11)
 
 ### Bug Fixes
 
 * **colors:** Remove repeated definition of color-light-gray-05
-
 
 # 5.0.2 (2020-01-08)
 

--- a/tokens/font-stack.yml
+++ b/tokens/font-stack.yml
@@ -1,5 +1,5 @@
 global:
-  type: string
+  type: font-family
   category: font-family
 imports:
   - ./_aliases.yml


### PR DESCRIPTION
## Description

Changes the `type` on the font stack tokens to `font-family`

- [x] I have recorded this change in `CHANGELOG.md`.

### Issue
#78 

### Testing

Run `gulp` to make sure it compiles, then check the generated output in `dist` to ensure it's correct and not quoted.