### PR TITLE
Migrate CI to GitHub actions, remove Travis

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,32 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x, 15.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    env:
+      DISPLAY: ":99.0"
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: setup xvfb
+      run: |
+        sudo apt install libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0
+        /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1920x1200x24 -ac +extension GLX
+    - run: npm ci
+    - run: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: node_js
-node_js:
-  - "10"
-cache: node_modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
+# HEAD
+
+## Features
+
+* Migrate CI to GitHub actions
+
 # 5.0.5 (2020-05-11)
 
 * **units:** Increase value of $layout-2xl unit (#82)
-* **content**: Update content sizes (#73)
+* **content:**: Update content sizes (#73)
 
 # 5.0.4 (2020-04-29)
 


### PR DESCRIPTION
## Description

Free Travis ended some time ago. This switches to GitHub actions for basic CI. I started from https://github.com/mozilla/protocol/blob/main/.github/workflows/node.js.yml and modified it slightly, I have no idea if this will work.

- [x] I have recorded this change in `CHANGELOG.md`.