### PR TITLE
Add Mozilla Headline and Text font stack tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Features
 
 * Migrate CI to GitHub actions
+* **fontstack:** (breaking) Adds Mozilla Headline and Mozilla Text to the font stacks. Removes `font-stack-mozilla`.
 
 # 5.0.5 (2020-05-11)
 

--- a/tokens/_aliases.yml
+++ b/tokens/_aliases.yml
@@ -211,4 +211,5 @@ aliases:
   font-stack-base: "Inter, X-LocaleSpecific, sans-serif"
   font-stack-firefox: "Metropolis, Inter, X-LocaleSpecific, sans-serif"
   font-stack-mono: "Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace"
-  font-stack-mozilla: "'Zilla Slab', Inter, X-LocaleSpecific, sans-serif"
+  font-stack-mozilla-text: "'Mozilla Text', Inter, 'Helvetica Neue', Arial, X-LocaleSpecific, sans-serif"
+  font-stack-mozilla-headline: "'Mozilla Headline', Inter, 'Helvetica Neue', Arial, X-LocaleSpecific, sans-serif"

--- a/tokens/font-stack.yml
+++ b/tokens/font-stack.yml
@@ -8,7 +8,9 @@ props:
     value: '{!font-stack-base}'
   - name: font-stack-firefox
     value: '{!font-stack-firefox}'
-  - name: font-stack-mozilla
-    value: '{!font-stack-mozilla}'
+  - name: font-stack-mozilla-headline
+    value: '{!font-stack-mozilla-headline}'
+  - name: font-stack-mozilla-text
+    value: '{!font-stack-mozilla-text}'
   - name: font-stack-mono
     value: '{!font-stack-mono}'


### PR DESCRIPTION
## Description

Removes outdated Zilla slab token and adds rebrand Mozilla fonts: Mozilla Headline and Mozilla Text

- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

https://github.com/mozilla/protocol/issues/1029

### Testing

Direct local `protocol` to use local `protocol-tokens` package. Run `npm install` and check the Protocol Documentation site shows the new fonts: https://github.com/mozilla/protocol/pull/1030
