### PR TITLE
Remove web font Inter from Mozilla font stacks (fixes #104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Features
 
 * Migrate CI to GitHub actions
-* **fontstack:** (breaking) Adds Mozilla Headline and Mozilla Text to the font stacks. Removes `font-stack-mozilla`.
+* **fontstack:** (breaking) Adds Mozilla Headline and Mozilla Text to the font stacks. Removes `font-stack-mozilla`. Also, removes Inter from Mozilla font stack. It's no longer used as body text (as it is in Firefox), so there's no reason to add another web font in front of the system fallback fonts.
 
 # 5.0.5 (2020-05-11)
 

--- a/tokens/_aliases.yml
+++ b/tokens/_aliases.yml
@@ -211,5 +211,5 @@ aliases:
   font-stack-base: "Inter, X-LocaleSpecific, sans-serif"
   font-stack-firefox: "Metropolis, Inter, X-LocaleSpecific, sans-serif"
   font-stack-mono: "Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace"
-  font-stack-mozilla-text: "'Mozilla Text', Inter, 'Helvetica Neue', Arial, X-LocaleSpecific, sans-serif"
-  font-stack-mozilla-headline: "'Mozilla Headline', Inter, 'Helvetica Neue', Arial, X-LocaleSpecific, sans-serif"
+  font-stack-mozilla-text: "'Mozilla Text', 'Helvetica Neue', Arial, X-LocaleSpecific, sans-serif"
+  font-stack-mozilla-headline: "'Mozilla Headline', 'Helvetica Neue', Arial, X-LocaleSpecific, sans-serif"


### PR DESCRIPTION
## Description

Remove Inter from Mozilla font stack. It's no longer used as body text, so there's no reason to add another web font in front of the system fonts.

Leaving for Firefox as it is used in Firefox body copy so needs to downloaded anyway. It's also a much closer match to the Metropolis title typeface, so any font swapping shouldn't be too jarring.

- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

https://github.com/mozilla/protocol-tokens/issues/104
