### PR TITLE
7.0.0 Mozilla colour updates, also font and link colour changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Features
 
-- Update Mozilla colour tokens to match new brand pallette
+- **colors:** (breaking) Update Mozilla color tokens to match new brand palette
 - Remove Inter from fallback list for Headings (Fix #104)
 - Remove token for color-link-visited-hover
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 7.0.0 (2025-09-25)
+
+## Features
+
+- Update Mozilla colour tokens to match new brand pallette
+- Remove Inter from fallback list for Headings (Fix #104)
+- Remove token for color-link-visited-hover
+
+## Migration Tips
+
+- Replace uses of color-link-visited-hover with color-link-visited
+
 # 6.0.0 (2025-03-24)
 
 ## Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - **colors:** (breaking) Update Mozilla color tokens to match new brand palette
 - **fontstack:** Remove Inter from fallback list for Headings (Fix #104)
-- Remove token for color-link-visited-hover
+- **colors:** (breaking) Remove token for color-link-visited-hover
 
 ## Migration Tips
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Migration Tips
 
+- Mozilla colour tokens changes are extensive
 - Replace uses of color-link-visited-hover with color-link-visited
 
 # 6.0.0 (2025-03-24)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Features
 
 - **colors:** (breaking) Update Mozilla color tokens to match new brand palette
-- Remove Inter from fallback list for Headings (Fix #104)
+- **fontstack:** Remove Inter from fallback list for Headings (Fix #104)
 - Remove token for color-link-visited-hover
 
 ## Migration Tips

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Design tokens for Protocol, Mozilla’s design system.
 </tr>
 <tr>
 <td>Version</td>
-<td><a href="https://github.com/mozilla/protocol-tokens/blob/master/CHANGELOG.md">6.0.0</a></td>
+<td><a href="https://github.com/mozilla/protocol-tokens/blob/master/CHANGELOG.md">7.0.0</a></td>
 </tr>
 </table>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@mozilla-protocol/tokens",
-    "version": "6.0.0",
+    "version": "7.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@mozilla-protocol/tokens",
-            "version": "6.0.0",
+            "version": "7.0.0",
             "license": "MPL-2.0",
             "devDependencies": {
                 "@eslint/eslintrc": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mozilla-protocol/tokens",
-    "version": "6.0.0",
+    "version": "7.0.0",
     "description": "Design tokens for Protocol, Mozilla’s design system",
     "main": "dist/index.js",
     "style": "dist/index.scss",

--- a/tokens/_aliases.yml
+++ b/tokens/_aliases.yml
@@ -152,18 +152,40 @@ aliases:
   color-link: '{!color-blue-50}'
   color-link-hover: '{!color-blue-60}'
   color-link-visited: '{!color-purple-50}'
-  color-link-visited-hover: '{!color-purple-60}'
 
   # Mozilla brand colors
-  color-moz-neon-blue: '#00ffff'
-  color-moz-lemon-yellow: '#fff44f'
-  color-moz-warm-red: '#ff4f5e'
-  color-moz-neon-green: '#54ffbd'
-  color-moz-dark-purple: '#6e008b'
-  color-moz-dark-green: '#005e5e'
-  color-moz-dark-blue: '#00458b'
-  color-moz-dark-gray: '#959595'
-  color-moz-light-gray: '#e7e5e2'
+  color-moz-black: '#161616'
+  color-moz-black-strong: '#000000'
+  color-moz-white: '#fafafa'
+  color-moz-white-strong: '#ffffff'
+  color-moz-green: '#00d230'
+  color-moz-green-light: '#d6ffcd'
+  color-moz-green-mid: '#28733f'
+  color-moz-green-dark: '#022611'
+  color-moz-orange: '#ff9456'
+  color-moz-orange-light: '#faf0e6'
+  color-moz-orange-mid: '#ff453f'
+  color-moz-orange-dark: '#330505'
+  color-moz-pink: '#ff97e2'
+  color-moz-pink-light: '#fff1f8'
+  color-moz-pink-mid: '#ae49ec'
+  color-moz-pink-dark: '#210340'
+  color-moz-gray: '#B3B3B3'
+  color-moz-gray-light: '#e8e8e8'
+  color-moz-gray-mid: '#6d6d6d'
+  color-moz-gray-dark: '#414141'
+  color-moz-aqua : '#87e3cd'
+  color-moz-aqua-light : '#cef5eb'
+  color-moz-aqua-mid : '#41bfae'
+  color-moz-aqua-dark : '#0a5656'
+  color-moz-seed : '#ddef30'
+  color-moz-seed-light : '#eef797'
+  color-moz-seed-mid : '#a99c23'
+  color-moz-seed-dark : '#423412'
+  color-moz-clay : '#dadeb2'
+  color-moz-clay-light : '#eaecd0'
+  color-moz-clay-mid : '#b2b895'
+  color-moz-clay-dark : '#697961'
 
   # Units
   spacing-xs: '4px'
@@ -210,7 +232,7 @@ aliases:
 
   # Font Stack
   font-stack-base: "Inter, X-LocaleSpecific, sans-serif"
-  font-stack-firefox: "Metropolis, Inter, X-LocaleSpecific, sans-serif"
+  font-stack-firefox: "Metropolis, X-LocaleSpecific, sans-serif"
   font-stack-mono: "Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace"
   font-stack-mozilla-text: "'Mozilla Text', 'Helvetica Neue', Arial, X-LocaleSpecific, sans-serif"
   font-stack-mozilla-headline: "'Mozilla Headline', 'Helvetica Neue', Arial, X-LocaleSpecific, sans-serif"

--- a/tokens/colors.yml
+++ b/tokens/colors.yml
@@ -521,46 +521,135 @@ props:
     value: '{!color-link-visited}'
     meta:
       friendlyName: Link:Visited
-  - name: color-link-visited-hover
-    value: '{!color-link-visited-hover}'
-    meta:
-      friendlyName: Link:Visited:Hover
+
 
 # Mozilla brand colors
 
-  - name: color-moz-neon-blue
-    value: '{!color-moz-neon-blue}'
+  - name: color-moz-black
+    value: '{!color-moz-black}'
     meta:
-      friendlyName: Mozilla Neon Blue
-  - name: color-moz-lemon-yellow
-    value: '{!color-moz-lemon-yellow}'
+      friendlyName: Mozilla Black
+  - name: color-moz-black-strong
+    value: '{!color-moz-black-strong}'
     meta:
-      friendlyName: Mozilla Lemon Yellow
-  - name: color-moz-warm-red
-    value: '{!color-moz-warm-red}'
+      friendlyName: Mozilla Black Strong
+  - name: color-moz-white
+    value: '{!color-moz-white}'
     meta:
-      friendlyName: Mozilla Warm Red
-  - name: color-moz-neon-green
-    value: '{!color-moz-neon-green}'
+      friendlyName: Mozilla White
+  - name: color-moz-white-strong
+    value: '{!color-moz-white-strong}'
     meta:
-      friendlyName: Mozilla Neon Green
-  - name: color-moz-dark-purple
-    value: '{!color-moz-dark-purple}'
+      friendlyName: Mozilla White Strong
+  - name: color-moz-green
+    value: '{!color-moz-green}'
     meta:
-      friendlyName: Mozilla Dark Purple
-  - name: color-moz-dark-green
-    value: '{!color-moz-dark-green}'
+      friendlyName: Mozilla Green
+  - name: color-moz-green-light
+    value: '{!color-moz-green-light}'
     meta:
-      friendlyName: Mozilla Dark Green
-  - name: color-moz-dark-blue
-    value: '{!color-moz-dark-blue}'
+      friendlyName: Mozilla Green +1
+  - name: color-moz-green-mid
+    value: '{!color-moz-green-mid}'
     meta:
-      friendlyName: Mozilla Dark Blue
-  - name: color-moz-dark-gray
-    value: '{!color-moz-dark-gray}'
+      friendlyName: Mozilla Green -1
+  - name: color-moz-green-dark
+    value: '{!color-moz-green-dark}'
     meta:
-      friendlyName: Mozilla Dark Gray
-  - name: color-moz-light-gray
-    value: '{!color-moz-light-gray}'
+      friendlyName: Mozilla Green -2
+  - name: color-moz-orange
+    value: '{!color-moz-orange}'
     meta:
-      friendlyName: Mozilla Light Gray
+      friendlyName: Mozilla Orange
+  - name: color-moz-orange-light
+    value: '{!color-moz-orange-light}'
+    meta:
+      friendlyName: Mozilla Orange +1
+  - name: color-moz-orange-mid
+    value: '{!color-moz-orange-mid}'
+    meta:
+      friendlyName: Mozilla Orange -1
+  - name: color-moz-orange-dark
+    value: '{!color-moz-orange-dark}'
+    meta:
+      friendlyName: Mozilla Orange -2
+  - name: color-moz-pink
+    value: '{!color-moz-pink}'
+    meta:
+      friendlyName: Mozilla Pink
+  - name: color-moz-pink-light
+    value: '{!color-moz-pink-light}'
+    meta:
+      friendlyName: Mozilla Pink +1
+  - name: color-moz-pink-mid
+    value: '{!color-moz-pink-mid}'
+    meta:
+      friendlyName: Mozilla Pink -1
+  - name: color-moz-pink-dark
+    value: '{!color-moz-pink-dark}'
+    meta:
+      friendlyName: Mozilla Pink -2
+  - name: color-moz-gray
+    value: '{!color-moz-gray}'
+    meta:
+      friendlyName: Mozilla Gray
+  - name: color-moz-gray-light
+    value: '{!color-moz-gray-light}'
+    meta:
+      friendlyName: Mozilla Gray +1
+  - name: color-moz-gray-mid
+    value: '{!color-moz-gray-mid}'
+    meta:
+      friendlyName: Mozilla Gray -1
+  - name: color-moz-gray-dark
+    value: '{!color-moz-gray-dark}'
+    meta:
+      friendlyName: Mozilla Gray -2
+  - name: color-moz-aqua
+    value: '{!color-moz-aqua}'
+    meta:
+      friendlyName: Mozilla Aqua
+  - name: color-moz-aqua-light
+    value: '{!color-moz-aqua-light}'
+    meta:
+      friendlyName: Mozilla Aqua +1
+  - name: color-moz-aqua-mid
+    value: '{!color-moz-aqua-mid}'
+    meta:
+      friendlyName: Mozilla Aqua -1
+  - name: color-moz-aqua-dark
+    value: '{!color-moz-aqua-dark}'
+    meta:
+      friendlyName: Mozilla Aqua -2
+  - name: color-moz-seed
+    value: '{!color-moz-seed}'
+    meta:
+      friendlyName: Mozilla Seed
+  - name: color-moz-seed-light
+    value: '{!color-moz-seed-light}'
+    meta:
+      friendlyName: Mozilla Seed +1
+  - name: color-moz-seed-mid
+    value: '{!color-moz-seed-mid}'
+    meta:
+      friendlyName: Mozilla Seed -1
+  - name: color-moz-seed-dark
+    value: '{!color-moz-seed-dark}'
+    meta:
+      friendlyName: Mozilla Seed -2
+  - name: color-moz-clay
+    value: '{!color-moz-clay}'
+    meta:
+      friendlyName: Mozilla Clay
+  - name: color-moz-clay-light
+    value: '{!color-moz-clay-light}'
+    meta:
+      friendlyName: Mozilla Clay +1
+  - name: color-moz-clay-mid
+    value: '{!color-moz-clay-mid}'
+    meta:
+      friendlyName: Mozilla Clay -1
+  - name: color-moz-clay-dark
+    value: '{!color-moz-clay-dark}'
+    meta:
+      friendlyName: Mozilla Clay -2


### PR DESCRIPTION
## Description

- Update Mozilla colour tokens
- Tweak Firefox font stack
- Remove link:visited:hover colour
- Publish as 7.0.0
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue

Fix https://github.com/mozilla/protocol-assets/issues/107

### Testing

- Aliases make sense and are consistent (I used the "friendly" names in the brand style guide so we can speak the same 
language)
- No iterations missing
- I had Copilot build me a a nice HTML table with the colour swatches turned into visible colours to check that the colours looked right. Maybe you want to do that too? Maybe it's enough that I did it.